### PR TITLE
Refactor save_comic function to improve parameter naming and clarity

### DIFF
--- a/backend/api/comics.py
+++ b/backend/api/comics.py
@@ -153,14 +153,14 @@ async def generate_thumbnail(raw_request: Request, request: ThumbnailRequest, cu
 
 @router.post("/save-comic")
 @limiter.limit("30/minute")
-async def save_comic(raw_request: Request, current_user: dict = Depends(get_current_user)):
+async def save_comic(request: Request, current_user: dict = Depends(get_current_user)):
     """
     Save a comic to the database
     Requires authentication via JWT token
     """
     try:
         # First, let's see the raw request data
-        raw_data = await raw_request.json()
+        raw_data = await request.json()
         logger.debug(f"Raw request data: {json.dumps(raw_data, indent=2)}")
         logger.debug(f"Raw data keys: {list(raw_data.keys())}")
         logger.info(f"Authenticated user: {current_user.get('email', 'Unknown')} (ID: {current_user.get('id', 'Unknown')})")


### PR DESCRIPTION
- Changed the parameter name from 'raw_request' to 'request' in the save_comic function for better readability and consistency with other functions.
- Updated the corresponding usage of the parameter to maintain functionality.

Result: Enhanced code clarity and maintainability in the comic saving process.