### PR TITLE
feat: implement play button functionality and enable edit button

### DIFF
--- a/backend/api/comics.py
+++ b/backend/api/comics.py
@@ -5,6 +5,7 @@ from schemas.comic import ComicArtRequest, ComicRequest, ThumbnailRequest
 from services.comic_storage import ComicStorageService
 from services.comic_generator import ComicArtGenerator
 from services.user_credits import UserCreditsService
+from services.audio_generator import audio_generator
 from auth_shared import get_current_user
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -13,6 +14,7 @@ import base64
 import os
 import logging
 from PIL import Image
+import httpx
 import io
 
 logger = logging.getLogger(__name__)
@@ -211,11 +213,275 @@ async def save_comic(request: Request, current_user: dict = Depends(get_current_
         
         logger.info(f"Saving comic with is_public={is_public}")
 
-        return await comic_storage_service.save_comic(user_id, comic_title, panels_payload, thumbnail_data, is_public)
+        # Auto-generate audio for panels that have narration but no audio_data
+        panels_with_audio = []
+        audio_generation_count = 0
+        
+        for panel in panels_payload:
+            narration = panel.get('narration')
+            audio_data = panel.get('audio_data')
+            
+            # If panel has narration but no audio, generate it
+            if narration and narration.strip() and not audio_data:
+                try:
+                    logger.info(f"Auto-generating audio for panel {panel['id']} with narration: '{narration[:50]}...'")
+                    
+                    # Check if user has sufficient credits (1 credit per narration)
+                    if not await credits_service.has_sufficient_credits(user_id, 1):
+                        logger.warning(f"Insufficient credits for auto audio generation for panel {panel['id']}")
+                        # Continue without audio generation
+                        panels_with_audio.append(panel)
+                        continue
+                    
+                    # Generate audio using the audio generator
+                    generated_audio = await audio_generator.generate_audio_base64(narration)
+                    
+                    # Update panel with generated audio
+                    panel['audio_data'] = generated_audio
+                    audio_generation_count += 1
+                    
+                    # Deduct 1 credit for audio generation
+                    try:
+                        new_balance = await credits_service.deduct_credits(user_id, 1)
+                        logger.info(f"Auto-generated audio for panel {panel['id']}. Deducted 1 credit. New balance: {new_balance}")
+                    except Exception as credit_error:
+                        logger.error(f"Failed to deduct credits for auto audio generation: {credit_error}")
+                        # Continue even if credit deduction fails
+                    
+                except Exception as audio_error:
+                    logger.error(f"Failed to auto-generate audio for panel {panel['id']}: {audio_error}", exc_info=True)
+                    # Continue without audio generation
+                
+            panels_with_audio.append(panel)
+        
+        if audio_generation_count > 0:
+            logger.info(f"Auto-generated audio for {audio_generation_count} panels during comic publishing")
+
+        return await comic_storage_service.save_comic(user_id, comic_title, panels_with_audio, thumbnail_data, is_public)
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error saving comic: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.post("/panels/{panel_id}/regenerate")
+@limiter.limit("10/minute")
+async def regenerate_panel_image(request: Request, panel_id: str, current_user: dict = Depends(get_current_user)):
+    """
+    Regenerate a panel's image with a new prompt while maintaining context
+    """
+    try:
+        logger.info(f"Regenerating image for panel {panel_id} for user {current_user.get('id')}")
+        raw_data = await request.json()
+        text_prompt = raw_data.get('text_prompt')
+        previous_panel_context = raw_data.get('previous_panel_context')
+        
+        if not text_prompt:
+            raise HTTPException(status_code=422, detail="Missing required field: text_prompt")
+        
+        # Check if user has sufficient credits (1 credit per panel)
+        if not await credits_service.has_sufficient_credits(current_user["id"], 1):
+            raise HTTPException(
+                status_code=402, 
+                detail="Insufficient credits. Please purchase more credits to generate comic panels."
+            )
+        
+        # Verify the panel exists and belongs to the user
+        user_id = current_user.get('id')
+        panel_check = comic_storage_service.supabase.table('comic_panels').select('id, comic_id, panel_number').eq('id', panel_id).execute()
+        
+        if not panel_check.data:
+            raise HTTPException(status_code=404, detail="Panel not found")
+        
+        panel_data = panel_check.data[0]
+        comic_id = panel_data['comic_id']
+        panel_number = panel_data['panel_number']
+        
+        # Check if the comic belongs to the user
+        comic_check = comic_storage_service.supabase.table('comics').select('id').eq('id', comic_id).eq('user_id', user_id).execute()
+        
+        if not comic_check.data:
+            raise HTTPException(status_code=403, detail="You don't have permission to edit this panel")
+        
+        # Prepare context prompt if previous panel context is provided or infer it automatically
+        context_image_data = None
+        if previous_panel_context:
+            # Accept either base64 or URL for image_data
+            context_prompt_value = previous_panel_context.get('prompt')
+            raw_context_image = previous_panel_context.get('image_data')
+
+            # If the context image looks like a URL, fetch and base64-encode it
+            if isinstance(raw_context_image, str) and raw_context_image.startswith('http'):
+                try:
+                    async with httpx.AsyncClient(timeout=20) as client:
+                        resp = await client.get(raw_context_image)
+                        resp.raise_for_status()
+                        context_image_data = base64.b64encode(resp.content).decode('utf-8')
+                        logger.info("Fetched context image from URL for regeneration")
+                except Exception as fetch_err:
+                    logger.warning(f"Failed to fetch context image from URL: {fetch_err}")
+                    context_image_data = None
+            else:
+                context_image_data = raw_context_image
+
+            text_prompt = f"Create the next scene using this context: {context_prompt_value}. {text_prompt}"
+            logger.info("Using provided previous panel context for panel regeneration")
+        else:
+            # Infer context automatically from DB if not provided
+            try:
+                # For panel 1 use thumbnail (panel 0); otherwise use (panel_number - 1)
+                prev_number = 0 if panel_number == 1 else (panel_number - 1)
+                prev_panel_resp = comic_storage_service.supabase.table('comic_panels') \
+                    .select('public_url,prompt,panel_number') \
+                    .eq('comic_id', comic_id).eq('panel_number', prev_number).execute()
+                if prev_panel_resp.data:
+                    prev = prev_panel_resp.data[0]
+                    prev_url = prev.get('public_url')
+                    prev_prompt = prev.get('prompt')
+                    if prev_url:
+                        async with httpx.AsyncClient(timeout=20) as client:
+                            resp = await client.get(prev_url)
+                            resp.raise_for_status()
+                            context_image_data = base64.b64encode(resp.content).decode('utf-8')
+                            logger.info(f"Auto-fetched context image from panel {prev_number}")
+                    if prev_prompt:
+                        text_prompt = f"Create the next scene using this context: {prev_prompt}. {text_prompt}"
+                else:
+                    logger.info("No previous panel found for context; proceeding without context")
+            except Exception as infer_err:
+                logger.warning(f"Failed to infer previous panel context: {infer_err}")
+        
+        # Generate the new image
+        image = comic_generator.generate_comic_art(text_prompt, None, context_image_data)
+        
+        # Convert to base64 for storage
+        img_base64 = comic_generator.image_to_base64(image)
+        
+        # Upload the image to Supabase storage
+        try:
+            img_bytes = base64.b64decode(img_base64)
+            file_path = f"users/{user_id}/comics/{comic_id}/panels/panel_{panel_number}_regenerated_{os.urandom(4).hex()}.png"
+            
+            upload_result = comic_storage_service.supabase.storage.from_('PixelPanel').upload(
+                file_path,
+                img_bytes,
+                {'content-type': 'image/png', 'upsert': 'true'}
+            )
+            
+            # Get public URL
+            public_url = comic_storage_service.supabase.storage.from_('PixelPanel').get_public_url(file_path)
+            
+            # Update the panel in the database with new image URL and prompt
+            update_result = comic_storage_service.supabase.table('comic_panels').update({
+                'public_url': public_url,
+                'prompt': text_prompt
+            }).eq('id', panel_id).execute()
+            
+            if not update_result.data:
+                raise HTTPException(status_code=500, detail="Failed to update panel")
+            
+            # Deduct 1 credit after successful generation
+            try:
+                new_balance = await credits_service.deduct_credits(user_id, 1)
+                logger.info(f"Deducted 1 credit from user {user_id}. New balance: {new_balance}")
+            except Exception as credit_error:
+                logger.error(f"Failed to deduct credits for user {user_id}: {credit_error}")
+            
+            logger.info(f"Successfully regenerated panel {panel_id} with new image URL: {public_url}")
+            
+            return {
+                "success": True,
+                "public_url": public_url,
+                "message": "Panel image regenerated successfully"
+            }
+            
+        except Exception as storage_error:
+            logger.error(f"Error uploading regenerated image: {storage_error}", exc_info=True)
+            raise HTTPException(status_code=500, detail=f"Failed to upload image: {str(storage_error)}")
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error regenerating panel {panel_id}: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.patch("/panels/{panel_id}")
+@limiter.limit("30/minute")
+async def update_panel(request: Request, panel_id: str, current_user: dict = Depends(get_current_user)):
+    """
+    Update a specific panel's narration and/or prompt
+    """
+    try:
+        logger.info(f"Updating panel {panel_id} for user {current_user.get('id')}")
+        raw_data = await request.json()
+        logger.info(f"Request data: {raw_data}")
+        narration = raw_data.get('narration')
+        prompt = raw_data.get('prompt')
+        
+        if narration is None and prompt is None:
+            raise HTTPException(status_code=422, detail="Missing required field: narration or prompt")
+        
+        # Prepare update data
+        update_data = {}
+        if narration is not None:
+            update_data['narration'] = narration
+        if prompt is not None:
+            update_data['prompt'] = prompt
+        
+        logger.info(f"Update data: {update_data}")
+        
+        # First, verify the panel exists and belongs to the user
+        user_id = current_user.get('id')
+        panel_check = comic_storage_service.supabase.table('comic_panels').select('id, comic_id, panel_number').eq('id', panel_id).execute()
+        
+        if not panel_check.data:
+            raise HTTPException(status_code=404, detail="Panel not found")
+        
+        # Check if the comic belongs to the user
+        comic_check = comic_storage_service.supabase.table('comics').select('id').eq('id', panel_check.data[0]['comic_id']).eq('user_id', user_id).execute()
+        
+        if not comic_check.data:
+            raise HTTPException(status_code=403, detail="You don't have permission to edit this panel")
+        
+        # If narration provided, (re)generate audio and upload; then update audio_url
+        audio_url = None
+        if narration is not None and isinstance(narration, str) and narration.strip():
+            try:
+                logger.info(f"Generating updated audio for panel {panel_id}")
+                # Generate audio base64
+                audio_b64 = await audio_generator.generate_audio_base64(narration)
+                # Upload to storage with upsert
+                audio_storage_path = f"users/{user_id}/comics/{panel_check.data[0]['comic_id']}/audio/panel_{panel_check.data[0]['panel_number']}.mp3"
+                audio_bytes = base64.b64decode(audio_b64)
+                comic_storage_service.supabase.storage.from_('PixelPanel').upload(
+                    path=audio_storage_path,
+                    file=audio_bytes,
+                    file_options={"content-type": "audio/mpeg", "upsert": "true"}
+                )
+                audio_url = comic_storage_service.supabase.storage.from_('PixelPanel').get_public_url(audio_storage_path)
+                update_data['audio_url'] = audio_url
+                # Deduct 1 credit upon successful generation
+                try:
+                    new_balance = await credits_service.deduct_credits(user_id, 1)
+                    logger.info(f"Deducted 1 credit for updated narration audio. New balance: {new_balance}")
+                except Exception as credit_error:
+                    logger.error(f"Failed to deduct credits for updated narration audio: {credit_error}")
+            except Exception as audio_err:
+                logger.error(f"Failed to generate/upload updated audio for panel {panel_id}: {audio_err}", exc_info=True)
+
+        # Update the panel in the database
+        result = comic_storage_service.supabase.table('comic_panels').update(update_data).eq('id', panel_id).execute()
+        
+        if not result.data:
+            raise HTTPException(status_code=500, detail="Failed to update panel")
+        
+        logger.info(f"Updated panel {panel_id} for user {user_id}: {list(update_data.keys())}")
+        return {"success": True, "message": "Panel updated successfully", "audio_url": audio_url}
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating panel {panel_id}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
 @router.get("/user-comics")

--- a/backend/main.py
+++ b/backend/main.py
@@ -42,7 +42,7 @@ app.add_middleware(
         # "https://your-frontend-domain.com",
     ],
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["*"],
 )
 

--- a/frontend/src/app/protected/confirm/page.tsx
+++ b/frontend/src/app/protected/confirm/page.tsx
@@ -516,6 +516,15 @@ export default function ConfirmComicPage() {
                       Generate narrations for all panels
                     </span>
                   </div>
+                  
+                  <div className="flex items-center space-x-2">
+                    <svg className="w-5 h-5 text-blue-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+                    </svg>
+                    <span className="text-foreground">
+                      Audio will be auto-generated during publishing
+                    </span>
+                  </div>
                 </div>
                 
                 {(!title.trim() || !thumbnailData || !panelsData.every(p => p.narration)) && (
@@ -536,7 +545,7 @@ export default function ConfirmComicPage() {
                   className="w-full flex items-center justify-center space-x-2 px-4 py-3 bg-accent hover:bg-accent-hover disabled:bg-background-muted disabled:cursor-not-allowed text-foreground-inverse rounded-lg transition-colors font-medium"
                 >
                   {loading ? (
-                    renderLoadingSpinner('Publishing...')
+                    renderLoadingSpinner('Publishing & generating audio...')
                   ) : (
                     <>
                       <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/frontend/src/app/protected/explore/page.tsx
+++ b/frontend/src/app/protected/explore/page.tsx
@@ -13,6 +13,7 @@ export default function ExplorePage() {
   const [error, setError] = useState<string | null>(null);
   const [selectedComic, setSelectedComic] = useState<Comic | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [autoPlay, setAutoPlay] = useState(false);
   const [imageLoading, setImageLoading] = useState<{[key: string]: boolean}>({});
   const [imageErrors, setImageErrors] = useState<{[key: string]: boolean}>({});
 
@@ -62,12 +63,21 @@ export default function ExplorePage() {
 
   const openModal = (comic: Comic) => {
     setSelectedComic(comic);
+    setAutoPlay(false);
+    setShowModal(true);
+  };
+
+  const openModalAndPlay = (comic: Comic, event: React.MouseEvent) => {
+    event.stopPropagation(); // Prevent the card click from firing
+    setSelectedComic(comic);
+    setAutoPlay(true);
     setShowModal(true);
   };
 
   const closeModal = () => {
     setSelectedComic(null);
     setShowModal(false);
+    setAutoPlay(false);
   };
 
   const handleImageLoadStart = (key: string) => {
@@ -119,7 +129,7 @@ export default function ExplorePage() {
   }
 
   return (
-    <div className="w-full h-full overflow-auto">
+    <div className="w-full h-full overflow-auto scrollbar-hide">
       <div className="max-w-7xl mx-auto px-6 md:px-8 lg:px-12">
         <div className="mb-8">
           <h1 className="text-3xl font-bold mb-2" style={{ color: 'var(--foreground)' }}>Explore Comics</h1>
@@ -191,6 +201,22 @@ export default function ExplorePage() {
                 )}
               </div>
 
+              {/* Play button overlay - only show if comic has audio */}
+              {comic.panels.some(p => p.audio_url && p.panel_number > 0) && (
+                <div className="absolute top-3 right-3">
+                  <button
+                    onClick={(e) => openModalAndPlay(comic, e)}
+                    className="bg-accent hover:bg-accent-hover text-white rounded-full p-2 transition-all duration-200 hover:scale-110 shadow-lg"
+                    aria-label="Play comic"
+                    title="Play comic with audio"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+                      <path d="M8 5v14l11-7z" />
+                    </svg>
+                  </button>
+                </div>
+              )}
+
               {/* Title and date at bottom with overlay */}
               <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/80 via-black/60 to-transparent p-3">
                 <h3 className="text-white font-semibold text-sm mb-1 line-clamp-2 leading-tight">{comic.title}</h3>
@@ -211,6 +237,7 @@ export default function ExplorePage() {
             comic={selectedComic}
             isOpen={showModal}
             onClose={closeModal}
+            autoPlay={autoPlay}
           />
         )}
       </div>

--- a/frontend/src/app/protected/layout.tsx
+++ b/frontend/src/app/protected/layout.tsx
@@ -56,7 +56,7 @@ export default function ProtectedLayout({
       
       {/* Main Content - Scrollable */}
       <div className="flex-1 flex flex-col overflow-hidden">
-        <main className="flex-1 p-6 overflow-y-auto" style={{ backgroundColor: 'var(--background)' }}>
+        <main className="flex-1 p-6 overflow-y-auto scrollbar-hide" style={{ backgroundColor: 'var(--background)' }}>
           {children}
         </main>
       </div>

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,7 +1,8 @@
 // API Configuration
 // Change this port to easily switch between different backend servers
 export const API_CONFIG = {
-  BASE_URL: process.env.NEXT_PUBLIC_API_URL || 'https://pixelpanel.onrender.com', // Use environment variable for production
+  // BASE_URL: process.env.NEXT_PUBLIC_API_URL || 'https://pixelpanel.onrender.com', // Use environment variable for production
+  BASE_URL: 'http://0.0.0.0:8000', // Use this for development
   ENDPOINTS: {
     // New modular API endpoints
     GENERATE: '/api/comics/generate',


### PR DESCRIPTION
- Add play button to comic thumbnails in explore and my comics pages
- Implement auto-play functionality that opens modal and plays full comic sequentially
- Unify play button behavior between explore and my comics pages
- Enable edit button in ComicDetailModal to navigate to edit page
- Update edit button styling to orange color scheme
- Fix localStorage quota issues with image compression
- Add automatic audio generation during comic publishing
- Fix authentication headers in API requests